### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/source/core/utils.js
+++ b/source/core/utils.js
@@ -38,11 +38,14 @@
 
     function clone(o) {return JSON.parse(JSON.stringify(o));}
 
+    function isBlacklisted(key) {return ['__proto__', 'constructor', 'prototype'].includes(key);}
+
     core.ut = {
         args2arr: args2arr,
         arrLoop: arrLoop,
         clone: clone,
         objLoop: objLoop,
-        pick_omit: pick_omit
+        pick_omit: pick_omit,
+        isBlacklisted: isBlacklisted
     };
 }()

--- a/source/methods/get.js
+++ b/source/methods/get.js
@@ -19,6 +19,7 @@ function get(obj, path, defaultValue) {
         there;
         
     while (++i < l) {
+        if (core.ut.isBlacklisted(els[i])) continue;
         there = els[i] in res;
         if (!there) return defaultValue || null;
         res = res[els[i]]; // still pure

--- a/source/methods/set.js
+++ b/source/methods/set.js
@@ -15,7 +15,7 @@ function set(obj, path, value) {
         tmp = res;
         
     for (null; i < l-1; i++) { 
-        if (!(els[i] in tmp) || core.in.isPrimitive(tmp[els[i]])) {
+        if (core.ut.isBlacklisted(els[i]) || !(els[i] in tmp) || core.in.isPrimitive(tmp[els[i]])) {
             //if next key is a number create an array, or use an obj
             tmp[els[i]] = els[i+1].match(/\d+/) ? [] : {};
         }

--- a/source/test/set.js
+++ b/source/test/set.js
@@ -155,6 +155,11 @@ describe('set', () => {
             assert.strictEqual(e.message, "Missing expected argument");
         }
     });
+
+    it('should not pollute object prototype', () => {
+        ow.set({}, '__proto__.polluted', true);
+        assert.strictEqual({}.polluted, undefined);
+    })
     
     it('∂ should be a pure function', () => {
         const o = [{a: 1},    


### PR DESCRIPTION
### :bar_chart: Metadata *

`objwun` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-objwun

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { set } = require('objwun')

console.log('Before: ' + {}.polluted)
set({}, '__proto__.polluted', true)
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i objwun # Install vulerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

*I've added unit test for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105946009-66b8b100-608c-11eb-90ae-f42acc7ec15c.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
